### PR TITLE
fix: correct course.html template structure causing UndefinedError

### DIFF
--- a/src/templates/course.html
+++ b/src/templates/course.html
@@ -1,27 +1,18 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
-    <title>{{ course.title }}</title>
-</head>
-<body>
-    {% extends 'layout.html' %}
+{% extends 'layout.html' %}
 
-    {% block content %}
-    <div class="course-details">
-        <h1>{{ course.title }}</h1>
-        <p>{{ course.description }}</p>
-        <h2>Instructor: {{ course.instructor }}</h2>
-        <h3>Duration: {{ course.duration }}</h3>
-        <h4>Topics Covered:</h4>
-        <ul>
-            {% for topic in course.topics %}
-                <li>{{ topic }}</li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endblock %}
-</body>
-</html>
+{% block title %}{{ course.title }}{% endblock %}
+
+{% block content %}
+<div class="course-details">
+    <h1>{{ course.title }}</h1>
+    <p>{{ course.description }}</p>
+    <h2>Instructor: {{ course.instructor }}</h2>
+    <h3>Duration: {{ course.duration }}</h3>
+    <h4>Topics Covered:</h4>
+    <ul>
+        {% for topic in course.topics %}
+            <li>{{ topic }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,7 +25,12 @@ class AppTestCase(unittest.TestCase):
     def test_course(self):
         response = self.app.get('/course/1')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Course Details', response.data)
+        self.assertIn(b'Introduction to Python', response.data)
+        self.assertIn(b'John Doe', response.data)
+
+    def test_course_not_found(self):
+        response = self.app.get('/course/999')
+        self.assertEqual(response.status_code, 404)
 
     def test_golang_course(self):
         response = self.app.get('/course/4')


### PR DESCRIPTION
Fixes #1

## Changes

- Move `{% extends 'layout.html' %}` to be the first tag in course.html
- Add `{% block title %}` for the page title
- Remove redundant HTML scaffold from child template
- Improve test_course to assert actual course data
- Add test_course_not_found for 404 handling

Generated with [Claude Code](https://claude.ai/code)